### PR TITLE
Added collective.frontpage branch

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -34,6 +34,7 @@ http-address = 8080
 environment-vars = zope_i18n_compile_mo_files true
 eggs =
     collective.sidebar
+    collective.frontpage
     Pillow
     Plone
     plone.staticresources

--- a/develop.cfg
+++ b/develop.cfg
@@ -18,3 +18,4 @@ eggs +=
 
 [sources]
 collective.sidebar = git git://github.com/collective/collective.sidebar.git branch=master
+collective.frontpage = git git://github.com/collective/collective.frontpage.git branch=issue_28_tokyo_compat


### PR DESCRIPTION
Added collective.frontpage to buildout, so it can be installed with tokyo, but it has to be done manually.