### PR TITLE
Adding mosaic Support to tokyo theme

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog
 - Use cards (Search results, related items)
   [olda-a]
 
+- Add Mosaic support (add rules.xml with diazo namespace)
+  [toalba]
+
 
 1.0.0 (2023-02-07)
 ------------------

--- a/src/plonetheme/tokyo/theme/manifest.cfg
+++ b/src/plonetheme/tokyo/theme/manifest.cfg
@@ -2,7 +2,7 @@
 title = Tokyo Theme
 description = A theme for Plone 6 Classic UI
 preview = preview.png
-rules =
+rules =  /++theme++plonetheme.tokyo/rules.xml
 prefix = /++theme++plonetheme.tokyo
 doctype = <!DOCTYPE html>
 
@@ -11,4 +11,4 @@ disabled-bundles =
 
 production-css = 
 tinymce-content-css = 
-production-js = 
+production-js =

--- a/src/plonetheme/tokyo/theme/rules.xml
+++ b/src/plonetheme/tokyo/theme/rules.xml
@@ -1,0 +1,3 @@
+<rules xmlns="http://namespaces.plone.org/diazo">
+
+</rules>


### PR DESCRIPTION
by adding a emtpy rules xml with diazo namespace we can have support for plone.app.mosaic